### PR TITLE
Remove extra spaces in raw code

### DIFF
--- a/javascripts/discourse/templates/modal/raw-post.hbs
+++ b/javascripts/discourse/templates/modal/raw-post.hbs
@@ -1,7 +1,5 @@
 {{#d-modal-body class="raw-post"}}
   {{#conditional-loading-spinner condition=loading}}
-    <pre>
-    {{rawPost}}
-    </pre>
+    <pre>{{rawPost}}</pre>
   {{/conditional-loading-spinner}}
 {{/d-modal-body}}


### PR DESCRIPTION
Reported here https://meta.discourse.org/t/raw-post-button/152542/13?u=qaisjp

First discourse-related contribution, apologies if there's something like `{-` which might trim surrounding whitespace. Although maybe that's not desired, as it might trim whitespace in the raw text itself too.